### PR TITLE
Fix/release fixes

### DIFF
--- a/backend/events/tests/test_event_creation.py
+++ b/backend/events/tests/test_event_creation.py
@@ -547,9 +547,19 @@ class UpcomingEventsListViewTest(APITestCase):
     def test_filter_by_this_week(self):
         """Test filtering events happening this week"""
         now = timezone.now()
-        this_week_event_time = (now + timedelta(days=2)).replace(
-            hour=12, minute=0, second=0, microsecond=0
-        )
+
+        # To make the test robust, we create an event for tomorrow, unless it's Sunday.
+        # If it's Sunday, an event for tomorrow would be next week,
+        # so we create one for later today.
+        if now.weekday() == 6:  # Sunday
+            this_week_event_time = now + timedelta(minutes=30)
+            # Handle edge case where adding time crosses midnight
+            if this_week_event_time.weekday() != 6:
+                this_week_event_time = now + timedelta(minutes=1)
+        else:
+            this_week_event_time = (now + timedelta(days=1)).replace(
+                hour=12, minute=0, second=0, microsecond=0
+            )
         Event.objects.create(
             name="This Week Event",
             date=this_week_event_time,

--- a/backend/setup.cfg
+++ b/backend/setup.cfg
@@ -18,4 +18,4 @@ exclude = (migrations|venv|.venv|__pycache__|backend/settings.py)
 [tool:pytest]
 DJANGO_SETTINGS_MODULE = backend.settings
 python_files = tests.py test_*.py *_tests.py
-addopts = --cov=backend --cov-report=term-missing --cov-fail-under=60
+addopts = --cov=. --cov-report=term-missing --cov-fail-under=60

--- a/frontend/app/create-event/page.tsx
+++ b/frontend/app/create-event/page.tsx
@@ -200,7 +200,7 @@ function CreateEventContent() {
         }
         // Use replace to remove create event page from history
         // Navigate immediately to ensure referrer is available when component mounts
-        router.replace(`/organizations/${selectedOrganizationId}`);
+        router.replace(`/organizations/detail?id=${selectedOrganizationId}`);
       }
     } catch (error) {
       setSubmitError("Failed to create event");

--- a/frontend/app/organizations/create/page.tsx
+++ b/frontend/app/organizations/create/page.tsx
@@ -218,7 +218,7 @@ export default function CreateOrganizationPage() {
       setEstablishedDate("");
       setFormErrors({});
       // Use replace instead of push to remove create page from history
-      router.replace(`/organizations/${organization.id}`);
+      router.replace(`/organizations/detail?id=${organization.id}`);
     } catch (err) {
       if (err && typeof err === "object") {
         // Handle validation errors from backend


### PR DESCRIPTION
Upon releasing the result of the 3rd iteration to staging and production, three errors were found:

1. We had actions in the web application redirecting to old dynamically generated pages, and not pages created using query string parameters, as per github pages requires

2. A flaky test had been detected in the backend, related to the temporal event filters, that would fail on certain days of the week

3. Running "pytest ." in the backend was reporting an incorrect code coverage value

This PR is meant to address those errors