### PR TITLE
Feature/event change notifications

### DIFF
--- a/backend/events/tests/test_event_notifications.py
+++ b/backend/events/tests/test_event_notifications.py
@@ -1,0 +1,287 @@
+from datetime import timedelta
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from accounts.models import Organization, Profile
+from notifications.models import Notification
+
+from ..models import Event
+from ..utils import detect_critical_changes
+
+User = get_user_model()
+
+
+class EventChangeNotificationTest(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.organizer = User.objects.create_user(
+            username="organizer", email="org@example.com", password="password123"
+        )
+        cls.organizer.profile.role = Profile.Role.ORGANIZER
+        cls.organizer.profile.save()
+
+        cls.interested_user1 = User.objects.create_user(
+            username="interested1",
+            email="int1@example.com",
+            password="password123",
+        )
+        cls.interested_user2 = User.objects.create_user(
+            username="interested2",
+            email="int2@example.com",
+            password="password123",
+        )
+        cls.participant_user = User.objects.create_user(
+            username="participant",
+            email="part@example.com",
+            password="password123",
+        )
+
+        cls.organization = Organization.objects.create(
+            name="Test Organization", owner=cls.organizer
+        )
+
+        cls.event = Event.objects.create(
+            name="Test Event",
+            date=timezone.now() + timedelta(days=7),
+            location="Original Location",
+            description="Test Description",
+            category="SOCIAL",
+            organizer=cls.organizer,
+            organization=cls.organization,
+        )
+
+        # Mark users as interested
+        cls.event.interested_users.add(cls.interested_user1, cls.interested_user2)
+        # Mark one user as participant
+        cls.event.participants.add(cls.participant_user)
+
+    def setUp(self):
+        self.client.force_authenticate(user=self.organizer)
+
+    def test_detect_critical_changes_date(self):
+        """Test that date changes are detected as critical"""
+        new_data = {"date": timezone.now() + timedelta(days=14)}
+        result = detect_critical_changes(self.event, new_data)
+        self.assertIsNotNone(result)
+        self.assertEqual(len(result["changes"]), 1)
+        self.assertEqual(result["changes"][0]["field"], "date")
+
+    def test_detect_critical_changes_location(self):
+        """Test that location changes are detected as critical"""
+        new_data = {"location": "New Location"}
+        result = detect_critical_changes(self.event, new_data)
+        self.assertIsNotNone(result)
+        self.assertEqual(len(result["changes"]), 1)
+        self.assertEqual(result["changes"][0]["field"], "location")
+
+    def test_detect_critical_changes_status(self):
+        """Test that status changes are detected as critical"""
+        new_data = {"status": "Cancelled"}
+        result = detect_critical_changes(self.event, new_data)
+        self.assertIsNotNone(result)
+        self.assertEqual(len(result["changes"]), 1)
+        self.assertEqual(result["changes"][0]["field"], "status")
+
+    def test_detect_non_critical_changes(self):
+        """Test that non-critical changes don't trigger notifications"""
+        new_data = {"description": "Updated Description"}
+        result = detect_critical_changes(self.event, new_data)
+        self.assertIsNone(result)
+
+        new_data = {"name": "Updated Name"}
+        result = detect_critical_changes(self.event, new_data)
+        self.assertIsNone(result)
+
+        new_data = {"category": "ACADEMIC"}
+        result = detect_critical_changes(self.event, new_data)
+        self.assertIsNone(result)
+
+    def test_detect_multiple_critical_changes(self):
+        """Test that multiple critical changes are detected"""
+        new_data = {
+            "date": timezone.now() + timedelta(days=14),
+            "location": "New Location",
+        }
+        result = detect_critical_changes(self.event, new_data)
+        self.assertIsNotNone(result)
+        self.assertEqual(len(result["changes"]), 2)
+
+    @patch("events.views.async_to_sync")
+    @patch("events.views.get_channel_layer")
+    def test_update_event_date_notifies_interested_users(
+        self, mock_channel_layer, mock_async
+    ):
+        """Test that updating event date notifies interested users"""
+        mock_channel_layer.return_value
+        new_date = timezone.now() + timedelta(days=14)
+
+        url = f"/api/events/{self.event.id}/"
+        response = self.client.patch(url, {"date": new_date.isoformat()}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # Check that notifications were created
+        notifications = Notification.objects.filter(
+            user__in=[self.interested_user1, self.interested_user2]
+        )
+        self.assertEqual(notifications.count(), 2)
+
+        # Check notification content
+        for notification in notifications:
+            self.assertIn("Event Updated", notification.title)
+            self.assertIn(self.event.name, notification.message)
+
+        # Check WebSocket messages were sent
+        self.assertEqual(mock_async.call_count, 2)
+
+    @patch("events.views.async_to_sync")
+    @patch("events.views.get_channel_layer")
+    def test_update_event_location_notifies_interested_users(
+        self, mock_channel_layer, mock_async
+    ):
+        """Test that updating event location notifies interested users"""
+        mock_channel_layer.return_value
+
+        url = f"/api/events/{self.event.id}/"
+        response = self.client.patch(url, {"location": "New Location"}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # Check that notifications were created
+        notifications = Notification.objects.filter(
+            user__in=[self.interested_user1, self.interested_user2]
+        )
+        self.assertEqual(notifications.count(), 2)
+
+    @patch("events.views.async_to_sync")
+    @patch("events.views.get_channel_layer")
+    def test_update_non_critical_field_no_notification(
+        self, mock_channel_layer, mock_async
+    ):
+        """Test that updating non-critical fields doesn't send notifications"""
+        mock_channel_layer.return_value
+
+        url = f"/api/events/{self.event.id}/"
+        response = self.client.patch(
+            url, {"description": "Updated Description"}, format="json"
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # Check that no notifications were created
+        notifications = Notification.objects.filter(
+            user__in=[self.interested_user1, self.interested_user2]
+        )
+        self.assertEqual(notifications.count(), 0)
+
+        # Check WebSocket messages were not sent
+        mock_async.assert_not_called()
+
+    @patch("events.views.async_to_sync")
+    @patch("events.views.get_channel_layer")
+    def test_cancel_event_notifies_interested_and_participants(
+        self, mock_channel_layer, mock_async
+    ):
+        """Test that cancelling event notifies both interested users and participants"""
+        mock_channel_layer.return_value
+
+        url = f"/api/events/{self.event.id}/cancel/"
+        response = self.client.post(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # Check that notifications were created for all users
+        all_users = [
+            self.interested_user1,
+            self.interested_user2,
+            self.participant_user,
+        ]
+        notifications = Notification.objects.filter(user__in=all_users)
+        self.assertEqual(notifications.count(), 3)
+
+        # Check notification content
+        for notification in notifications:
+            self.assertIn("Event Cancelled", notification.title)
+            self.assertIn(self.event.name, notification.message)
+
+        # Check WebSocket messages were sent
+        self.assertEqual(mock_async.call_count, 3)
+
+    @patch("events.views.async_to_sync")
+    @patch("events.views.get_channel_layer")
+    def test_update_same_value_no_notification(self, mock_channel_layer, mock_async):
+        """Test that updating with same values doesn't trigger notifications"""
+        mock_channel_layer.return_value
+
+        url = f"/api/events/{self.event.id}/"
+        # Update with same location
+        response = self.client.patch(
+            url, {"location": self.event.location}, format="json"
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # Check that no notifications were created
+        notifications = Notification.objects.filter(
+            user__in=[self.interested_user1, self.interested_user2]
+        )
+        self.assertEqual(notifications.count(), 0)
+
+    def test_multiple_users_receive_notifications(self):
+        """Test that multiple interested users all receive notifications"""
+        # Create additional interested user
+        new_user = User.objects.create_user(
+            username="new_interested",
+            email="new@example.com",
+            password="password123",
+        )
+        self.event.interested_users.add(new_user)
+
+        with patch("events.views.async_to_sync") as mock_async, patch(
+            "events.views.get_channel_layer"
+        ) as mock_channel_layer:
+            mock_channel_layer.return_value
+            new_date = timezone.now() + timedelta(days=14)
+
+            url = f"/api/events/{self.event.id}/"
+            response = self.client.patch(
+                url, {"date": new_date.isoformat()}, format="json"
+            )
+
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+            # Check that notifications were created for all 3 interested users
+            notifications = Notification.objects.filter(
+                user__in=[self.interested_user1, self.interested_user2, new_user]
+            )
+            self.assertEqual(notifications.count(), 3)
+
+            # Check WebSocket messages were sent to all 3 users
+            self.assertEqual(mock_async.call_count, 3)
+
+    def test_notification_persistence(self):
+        """Test that notifications are persisted in database"""
+        with patch("events.views.async_to_sync"), patch(
+            "events.views.get_channel_layer"
+        ):
+            new_date = timezone.now() + timedelta(days=14)
+
+            url = f"/api/events/{self.event.id}/"
+            response = self.client.patch(
+                url, {"date": new_date.isoformat()}, format="json"
+            )
+
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+            # Check notifications exist in database
+            notification = Notification.objects.filter(
+                user=self.interested_user1
+            ).first()
+            self.assertIsNotNone(notification)
+            self.assertFalse(notification.is_read)  # Should be unread by default
+            self.assertIn("Event Updated", notification.title)
+            self.assertIn(self.event.name, notification.message)

--- a/backend/events/utils.py
+++ b/backend/events/utils.py
@@ -1,0 +1,80 @@
+"""
+Utility functions for event management.
+"""
+
+
+def detect_critical_changes(old_event, new_data):
+    """
+    Detect if critical fields have changed in an event update.
+
+    Critical fields: date, location, status
+    Non-critical fields: name, description, category, capacity
+
+    Args:
+        old_event: The Event instance before update
+        new_data: Dictionary with new field values from request
+
+    Returns:
+        Dictionary with change information if critical changes detected:
+        {
+            'changes': [
+                {
+                    'field': 'date'|'location'|'status',
+                    'old_value': old_value,
+                    'new_value': new_value
+                }
+            ]
+        }
+        None if no critical changes detected
+    """
+    changes = []
+
+    # Check date changes
+    if "date" in new_data:
+        new_date = new_data["date"]
+        # Handle both string and datetime objects
+        if isinstance(new_date, str):
+            from django.utils.dateparse import parse_datetime
+
+            new_date = parse_datetime(new_date)
+
+        if new_date and old_event.date != new_date:
+            changes.append(
+                {
+                    "field": "date",
+                    "old_value": old_event.date.isoformat() if old_event.date else None,
+                    "new_value": new_date.isoformat() if new_date else None,
+                }
+            )
+
+    # Check location changes
+    if "location" in new_data:
+        new_location = new_data["location"]
+        old_location = old_event.location or ""
+        new_location_str = new_location or ""
+
+        if old_location.strip() != new_location_str.strip():
+            changes.append(
+                {
+                    "field": "location",
+                    "old_value": old_location,
+                    "new_value": new_location_str,
+                }
+            )
+
+    # Check status changes
+    if "status" in new_data:
+        new_status = new_data["status"]
+        if old_event.status != new_status:
+            changes.append(
+                {
+                    "field": "status",
+                    "old_value": old_event.status,
+                    "new_value": new_status,
+                }
+            )
+
+    if changes:
+        return {"changes": changes}
+
+    return None

--- a/backend/events/views.py
+++ b/backend/events/views.py
@@ -17,6 +17,122 @@ from notifications.models import Notification
 
 from .models import Event
 from .serializers import EventSerializer, UserSerializer
+from .utils import detect_critical_changes
+
+
+def notify_interested_users(event, notification_type, change_data):
+    """
+    Notify interested users and participants about event changes.
+
+    Args:
+        event: The Event instance
+        notification_type: 'event_updated' or 'event_cancelled'
+        change_data: Dictionary with change information
+    """
+    channel_layer = get_channel_layer()
+
+    # Get all interested users
+    interested_users = event.interested_users.all()
+
+    # For cancellations, also notify participants
+    if notification_type == "event_cancelled":
+        participants = event.participants.all()
+        # Combine interested users and participants, avoiding duplicates
+        all_users = set(interested_users) | set(participants)
+    else:
+        all_users = interested_users
+
+    if not all_users:
+        return
+
+    # Build notification message based on change type
+    if notification_type == "event_cancelled":
+        title = f"Event Cancelled: {event.name}"
+        message = f"The event '{event.name}' has been cancelled."
+        ws_message = {
+            "type": "event_cancelled",
+            "event_id": event.id,
+            "event_name": event.name,
+            "message": message,
+        }
+    elif notification_type == "event_updated":
+        # Build message from change data
+        change_messages = []
+        for change in change_data.get("changes", []):
+            field = change["field"]
+            old_val = change["old_value"]
+            new_val = change["new_value"]
+
+            if field == "date":
+                # Format dates nicely
+                try:
+                    from django.utils.dateparse import parse_datetime
+
+                    old_dt = parse_datetime(old_val) if old_val else None
+                    new_dt = parse_datetime(new_val) if new_val else None
+                    if old_dt and new_dt:
+                        old_str = old_dt.strftime("%B %d, %Y at %I:%M %p")
+                        new_str = new_dt.strftime("%B %d, %Y at %I:%M %p")
+                        change_messages.append(
+                            f"Event time changed from {old_str} to {new_str}"
+                        )
+                    else:
+                        change_messages.append("Event time changed")
+                except (ValueError, TypeError):
+                    change_messages.append("Event time changed")
+            elif field == "location":
+                old_loc = old_val or "TBA"
+                new_loc = new_val or "TBA"
+                change_messages.append(
+                    f"Event location changed from {old_loc} to {new_loc}"
+                )
+            elif field == "status":
+                change_messages.append(
+                    f"Event status changed from {old_val} to {new_val}"
+                )
+
+        message_text = ". ".join(change_messages)
+        title = f"Event Updated: {event.name}"
+        message = f"{event.name}: {message_text}"
+
+        # Determine change type for WebSocket message
+        change_type = (
+            change_data["changes"][0]["field"] if change_data.get("changes") else "unknown"
+        )
+
+        ws_message = {
+            "type": "event_updated",
+            "event_id": event.id,
+            "event_name": event.name,
+            "change_type": change_type,
+            "old_value": change_data["changes"][0]["old_value"]
+            if change_data.get("changes")
+            else None,
+            "new_value": change_data["changes"][0]["new_value"]
+            if change_data.get("changes")
+            else None,
+            "message": message_text,
+        }
+    else:
+        return  # Unknown notification type
+
+    # Create notifications and send WebSocket messages
+    for user in all_users:
+        # Create database notification
+        Notification.objects.create(
+            user=user,
+            title=title,
+            message=message,
+        )
+
+        # Send WebSocket notification
+        async_to_sync(channel_layer.group_send)(
+            f"notifications_{user.id}",
+            {
+                "type": "send_notification",
+                "message": ws_message,
+            },
+        )
 
 
 class EventListCreateView(generics.ListCreateAPIView):

--- a/backend/events/views.py
+++ b/backend/events/views.py
@@ -97,7 +97,9 @@ def notify_interested_users(event, notification_type, change_data):
 
         # Determine change type for WebSocket message
         change_type = (
-            change_data["changes"][0]["field"] if change_data.get("changes") else "unknown"
+            change_data["changes"][0]["field"]
+            if change_data.get("changes")
+            else "unknown"
         )
 
         ws_message = {
@@ -105,12 +107,16 @@ def notify_interested_users(event, notification_type, change_data):
             "event_id": event.id,
             "event_name": event.name,
             "change_type": change_type,
-            "old_value": change_data["changes"][0]["old_value"]
-            if change_data.get("changes")
-            else None,
-            "new_value": change_data["changes"][0]["new_value"]
-            if change_data.get("changes")
-            else None,
+            "old_value": (
+                change_data["changes"][0]["old_value"]
+                if change_data.get("changes")
+                else None
+            ),
+            "new_value": (
+                change_data["changes"][0]["new_value"]
+                if change_data.get("changes")
+                else None
+            ),
             "message": message_text,
         }
     else:

--- a/backend/events/views.py
+++ b/backend/events/views.py
@@ -237,9 +237,13 @@ class EventRetrieveUpdateDestroyView(generics.RetrieveUpdateDestroyAPIView):
         )
 
     def update(self, request, *args, **kwargs):
-        print("Event update called!")
         partial = kwargs.pop("partial", False)
         instance = self.get_object()
+
+        # Store original instance for comparison
+        original_date = instance.date
+        original_location = instance.location
+        original_status = instance.status
 
         # Permissions
         is_owner = instance.organization.owner == request.user
@@ -266,9 +270,30 @@ class EventRetrieveUpdateDestroyView(generics.RetrieveUpdateDestroyAPIView):
                     status=status.HTTP_400_BAD_REQUEST,
                 )
 
+        # Prepare data for change detection (include original values if not in request)
+        change_detection_data = request.data.copy()
+        if partial:
+            # For partial updates, include original values for fields not being updated
+            if "date" not in change_detection_data:
+                change_detection_data["date"] = original_date
+            if "location" not in change_detection_data:
+                change_detection_data["location"] = original_location
+            if "status" not in change_detection_data:
+                change_detection_data["status"] = original_status
+
+        # Detect critical changes before update
+        critical_changes = detect_critical_changes(instance, change_detection_data)
+
         serializer = self.get_serializer(instance, data=request.data, partial=partial)
         serializer.is_valid(raise_exception=True)
         self.perform_update(serializer)
+
+        # Refresh instance to get updated values
+        instance.refresh_from_db()
+
+        # If critical changes detected, notify interested users
+        if critical_changes:
+            notify_interested_users(instance, "event_updated", critical_changes)
 
         return Response(serializer.data)
 
@@ -514,6 +539,9 @@ class CancelEventView(APIView):
 
         event.status = "Canceled"
         event.save()
+
+        # Notify interested users and participants about cancellation
+        notify_interested_users(event, "event_cancelled", None)
 
         serializer = EventSerializer(event)
         return Response(serializer.data, status=status.HTTP_200_OK)

--- a/frontend/app/notifications/page.tsx
+++ b/frontend/app/notifications/page.tsx
@@ -20,11 +20,18 @@ export default function NotificationsPage() {
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [remindersEnabled, setRemindersEnabled] = useState(true);
+  const [eventChangesEnabled, setEventChangesEnabled] = useState(true);
 
   useEffect(() => {
     const storedPreference = localStorage.getItem("remindersEnabled");
     if (storedPreference !== null) {
       setRemindersEnabled(JSON.parse(storedPreference));
+    }
+    const storedEventChangesPreference = localStorage.getItem(
+      "eventChangesEnabled",
+    );
+    if (storedEventChangesPreference !== null) {
+      setEventChangesEnabled(JSON.parse(storedEventChangesPreference));
     }
   }, []);
 
@@ -36,14 +43,35 @@ export default function NotificationsPage() {
     }
   };
 
-  const load = async (remindersAllowed: boolean) => {
+  const handleEventChangesToggle = (enabled: boolean) => {
+    setEventChangesEnabled(enabled);
+    localStorage.setItem("eventChangesEnabled", JSON.stringify(enabled));
+    if (onNotificationReceivedCallback) {
+      onNotificationReceivedCallback();
+    }
+  };
+
+  const load = async (
+    remindersAllowed: boolean,
+    eventChangesAllowed: boolean,
+  ) => {
     try {
       setLoading(true);
       setError(null);
       const data = await listNotifications();
-      const filteredData = remindersAllowed
-        ? data
-        : data.filter((item) => item.title !== "Event Reminder");
+      let filteredData = data;
+      if (!remindersAllowed) {
+        filteredData = filteredData.filter(
+          (item) => item.title !== "Event Reminder",
+        );
+      }
+      if (!eventChangesAllowed) {
+        filteredData = filteredData.filter(
+          (item) =>
+            !item.title.startsWith("Event Updated:") &&
+            !item.title.startsWith("Event Cancelled:"),
+        );
+      }
       setItems(filteredData);
     } catch (e) {
       console.error(e);
@@ -54,8 +82,8 @@ export default function NotificationsPage() {
   };
 
   useEffect(() => {
-    load(remindersEnabled);
-  }, [remindersEnabled]);
+    load(remindersEnabled, eventChangesEnabled);
+  }, [remindersEnabled, eventChangesEnabled]);
 
   const toggleRead = async (id: number, nextRead: boolean) => {
     try {
@@ -106,15 +134,27 @@ export default function NotificationsPage() {
 
       <div className="mb-6">
         <h2 className="text-xl font-bold mb-2">Notification Preferences</h2>
-        <div className="flex items-center space-x-2">
-          <Switch
-            id="reminders-enabled"
-            checked={remindersEnabled}
-            onCheckedChange={handleReminderToggle}
-          />
-          <Label htmlFor="reminders-enabled">
-            Enable Upcoming Event Reminders
-          </Label>
+        <div className="space-y-3">
+          <div className="flex items-center space-x-2">
+            <Switch
+              id="reminders-enabled"
+              checked={remindersEnabled}
+              onCheckedChange={handleReminderToggle}
+            />
+            <Label htmlFor="reminders-enabled">
+              Enable Upcoming Event Reminders
+            </Label>
+          </div>
+          <div className="flex items-center space-x-2">
+            <Switch
+              id="event-changes-enabled"
+              checked={eventChangesEnabled}
+              onCheckedChange={handleEventChangesToggle}
+            />
+            <Label htmlFor="event-changes-enabled">
+              Enable Event Change Notifications
+            </Label>
+          </div>
         </div>
       </div>
 

--- a/frontend/lib/websockets.ts
+++ b/frontend/lib/websockets.ts
@@ -19,9 +19,30 @@ type NewEventMsg = {
   start_time?: string;
 };
 
+type EventUpdatedMsg = {
+  type: "event_updated";
+  event_id?: number;
+  event_name?: string;
+  change_type?: string;
+  old_value?: string;
+  new_value?: string;
+  message?: string;
+};
+
+type EventCancelledMsg = {
+  type: "event_cancelled";
+  event_id?: number;
+  event_name?: string;
+  message?: string;
+};
+
 type SendNotificationEnvelope = {
   type?: string; // "send_notification" from backend
-  message?: EventReminderMsg | NewEventMsg;
+  message?:
+    | EventReminderMsg
+    | NewEventMsg
+    | EventUpdatedMsg
+    | EventCancelledMsg;
 };
 
 function isObject(x: unknown): x is Record<string, unknown> {
@@ -32,6 +53,12 @@ function isEventReminder(x: unknown): x is EventReminderMsg {
 }
 function isNewEvent(x: unknown): x is NewEventMsg {
   return isObject(x) && x["type"] === "new_event";
+}
+function isEventUpdated(x: unknown): x is EventUpdatedMsg {
+  return isObject(x) && x["type"] === "event_updated";
+}
+function isEventCancelled(x: unknown): x is EventCancelledMsg {
+  return isObject(x) && x["type"] === "event_cancelled";
 }
 
 export const connectWebSocket = (userId: string) => {
@@ -80,6 +107,38 @@ export const connectWebSocket = (userId: string) => {
       const org = msg.organization_name ?? "Organization";
       const name = msg.event_name ?? "New Event";
       toast.info(`New Event: ${org} published "${name}".`);
+      console.debug("[ws] message type:", msg.type, msg);
+    } else if (isEventUpdated(msg)) {
+      // Show event update notifications
+      const name = msg.event_name ?? "Event";
+      const changeMsg = msg.message ?? "Event details have been updated";
+      toast.info(`Event Updated: ${name} - ${changeMsg}`, {
+        action: msg.event_id
+          ? {
+              label: "View Event",
+              onClick: () => {
+                // Navigate to event page - using window.location for simplicity
+                // Could be enhanced to use Next.js router if available in context
+                window.location.href = `/event?id=${msg.event_id}`;
+              },
+            }
+          : undefined,
+      });
+      console.debug("[ws] message type:", msg.type, msg);
+    } else if (isEventCancelled(msg)) {
+      // Show event cancellation notifications
+      const name = msg.event_name ?? "Event";
+      const cancelMsg = msg.message ?? "This event has been cancelled";
+      toast.warning(`Event Cancelled: ${name} - ${cancelMsg}`, {
+        action: msg.event_id
+          ? {
+              label: "View Event",
+              onClick: () => {
+                window.location.href = `/event?id=${msg.event_id}`;
+              },
+            }
+          : undefined,
+      });
       console.debug("[ws] message type:", msg.type, msg);
     } else if (msg !== null && msg !== undefined) {
       console.debug("[ws] message (unrecognized payload):", msg);

--- a/frontend/lib/websockets.ts
+++ b/frontend/lib/websockets.ts
@@ -109,36 +109,54 @@ export const connectWebSocket = (userId: string) => {
       toast.info(`New Event: ${org} published "${name}".`);
       console.debug("[ws] message type:", msg.type, msg);
     } else if (isEventUpdated(msg)) {
-      // Show event update notifications
-      const name = msg.event_name ?? "Event";
-      const changeMsg = msg.message ?? "Event details have been updated";
-      toast.info(`Event Updated: ${name} - ${changeMsg}`, {
-        action: msg.event_id
-          ? {
-              label: "View Event",
-              onClick: () => {
-                // Navigate to event page - using window.location for simplicity
-                // Could be enhanced to use Next.js router if available in context
-                window.location.href = `/event?id=${msg.event_id}`;
-              },
-            }
-          : undefined,
-      });
+      // Gate event_updated by local preference
+      const eventChangesEnabled = localStorage.getItem("eventChangesEnabled");
+      const eventChangesAllowed =
+        eventChangesEnabled === null ||
+        (eventChangesEnabled === "true" || eventChangesEnabled === "false"
+          ? JSON.parse(eventChangesEnabled)
+          : true);
+
+      if (eventChangesAllowed) {
+        const name = msg.event_name ?? "Event";
+        const changeMsg = msg.message ?? "Event details have been updated";
+        toast.info(`Event Updated: ${name} - ${changeMsg}`, {
+          action: msg.event_id
+            ? {
+                label: "View Event",
+                onClick: () => {
+                  // Navigate to event page - using window.location for simplicity
+                  // Could be enhanced to use Next.js router if available in context
+                  window.location.href = `/event?id=${msg.event_id}`;
+                },
+              }
+            : undefined,
+        });
+      }
       console.debug("[ws] message type:", msg.type, msg);
     } else if (isEventCancelled(msg)) {
-      // Show event cancellation notifications
-      const name = msg.event_name ?? "Event";
-      const cancelMsg = msg.message ?? "This event has been cancelled";
-      toast.warning(`Event Cancelled: ${name} - ${cancelMsg}`, {
-        action: msg.event_id
-          ? {
-              label: "View Event",
-              onClick: () => {
-                window.location.href = `/event?id=${msg.event_id}`;
-              },
-            }
-          : undefined,
-      });
+      // Gate event_cancelled by local preference
+      const eventChangesEnabled = localStorage.getItem("eventChangesEnabled");
+      const eventChangesAllowed =
+        eventChangesEnabled === null ||
+        (eventChangesEnabled === "true" || eventChangesEnabled === "false"
+          ? JSON.parse(eventChangesEnabled)
+          : true);
+
+      if (eventChangesAllowed) {
+        const name = msg.event_name ?? "Event";
+        const cancelMsg = msg.message ?? "This event has been cancelled";
+        toast.warning(`Event Cancelled: ${name} - ${cancelMsg}`, {
+          action: msg.event_id
+            ? {
+                label: "View Event",
+                onClick: () => {
+                  window.location.href = `/event?id=${msg.event_id}`;
+                },
+              }
+            : undefined,
+        });
+      }
       console.debug("[ws] message type:", msg.type, msg);
     } else if (msg !== null && msg !== undefined) {
       console.debug("[ws] message (unrecognized payload):", msg);


### PR DESCRIPTION
# Summary

## Description

This PR implements real-time WebSocket notifications for users who have marked interest in events when critical changes occur (date, time, location, cancellation). The feature includes a user preference toggle to enable/disable these notifications.

## User Story

As an Erasmus student who has marked interest in an event, I want to receive real-time WebSocket notifications when an event I'm interested in has critical changes (like time, location, or cancellation), so that I can adjust my plans immediately when event details change unexpectedly.

## Features Implemented

### Backend
- **Critical Change Detection**: Utility function to detect changes in critical fields (date, location, status)
- **Notification Helper**: Centralized function to send WebSocket and database notifications
- **Event Update Notifications**: Notifies interested users when event date, location, or status changes
- **Event Cancellation Notifications**: Notifies both interested users and participants when events are cancelled
- **Database Persistence**: All notifications are stored in the database for history

### Frontend
- **WebSocket Handlers**: Real-time toast notifications for event updates and cancellations
- **User Preference Toggle**: Toggle in Notification Preferences to enable/disable event change notifications
- **Notification Filtering**: Event change notifications are filtered from the list when preference is disabled
- **Navigation**: Clickable action buttons in notifications to navigate to event details

### Critical vs Non-Critical Fields

**Critical** (triggers notifications):
- `date` - Event date/time
- `location` - Event location
- `status` - Event status

**Non-Critical** (no notifications):
- `name` - Event name
- `description` - Event description
- `category` - Event category
- `capacity` - Event capacity

## How to Test

1. **Mark Interest**: As a student, mark interest in an event
2. **Update Event**: As an organizer, update the event's date, location, or status
3. **Verify Notification**: Check that interested users receive WebSocket toast notifications
4. **Check Database**: Verify notifications are stored in the database
5. **Test Preference**: Toggle event change notifications in Notification Preferences
6. **Test Cancellation**: Cancel an event and verify both interested users and participants are notified